### PR TITLE
Speed up intro preload experience

### DIFF
--- a/index.html
+++ b/index.html
@@ -543,6 +543,11 @@ header.ripple span.figtree-adrift {
   const doubtCounter = document.getElementById('doubt-counter');
 
   /* === ADDED: preload helpers and loading UI === */
+  const PRELOAD_MAX_WAIT_MS = 2600;
+  const MEDIA_GRACE_MS = 1600;
+
+  const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
   function preloadVideo(videoEl){
     return new Promise((resolve) => {
       if (!videoEl) return resolve();
@@ -583,16 +588,29 @@ header.ripple span.figtree-adrift {
     });
   }
 
+  function ensurePlaceholderDoubts(message = '(loading doubts…)') {
+    if (APPROVED_DOUBTS.length > 0) return;
+    const today = new Date().toISOString().slice(0, 10);
+    APPROVED_DOUBTS = [{ id: `placeholder-${today}`, text: message, date: today }];
+    initializeDoubtPool();
+  }
+
   async function preloadData(){
-    try{
-      // Use existing fetchers so first frame has content
-      APPROVED_DOUBTS = await fetchApprovedDoubts(600);
-      if (APPROVED_DOUBTS.length === 0) {
-        APPROVED_DOUBTS = [{ id:'p1', text:'(waiting for first approved doubt…)', date:new Date().toISOString().slice(0,10) }];
-      }
-      initializeDoubtPool();
-      // Seed boats so render is immediate
+    ensurePlaceholderDoubts('(loading doubts…)');
+    if (!boats || boats.length === 0) {
       boats = Array.from({length: BOAT_COUNT}, ()=> new Boat());
+    }
+
+    try{
+      let fetched = await fetchApprovedDoubts(600);
+      if (!Array.isArray(fetched) || fetched.length === 0) {
+        fetched = [{ id:'p1', text:'(waiting for first approved doubt…)', date:new Date().toISOString().slice(0,10) }];
+      }
+      APPROVED_DOUBTS = fetched;
+      initializeDoubtPool();
+      // Seed boats so render is immediate with fresh data
+      boats = Array.from({length: BOAT_COUNT}, ()=> new Boat());
+
       // Warm up counter silently
       const count = await fetchTotalDoubts().catch(()=>0);
       if (doubtCounter) {
@@ -610,9 +628,12 @@ header.ripple span.figtree-adrift {
       if (!APPROVED_DOUBTS?.length) {
         APPROVED_DOUBTS = [{ id:'p1', text:'(temporarily unable to load doubts)', date:new Date().toISOString().slice(0,10) }];
         initializeDoubtPool();
+      }
+      if (!boats || boats.length === 0) {
         boats = Array.from({length: BOAT_COUNT}, ()=> new Boat());
       }
       if (doubtCounter) {
+        doubtCounter.style.visibility = 'visible';
         doubtCounter.textContent = '0 doubts released';
         doubtCounter.dataset.startValue = '0';
       }
@@ -627,12 +648,26 @@ header.ripple span.figtree-adrift {
     const rainP  = preloadScriptAlreadyInPage('rain.js');
     const dataP  = preloadData();
 
-    // Safety cap so we don’t hang forever waiting on a stubborn canplaythrough
-    const cap = new Promise(res => setTimeout(res, 7000));
+    const essentials = Promise.all([
+      Promise.race([videoP.catch(()=>{}), delay(MEDIA_GRACE_MS)]),
+      Promise.race([fontsP.catch(()=>{}), delay(MEDIA_GRACE_MS)]),
+      rainP.catch(()=>{}),
+      dataP.catch(()=>{})
+    ]);
+
+    essentials.then(() => {
+      preloadAllDone = true;
+    }).catch((err) => {
+      console.error('Essential preload failed:', err);
+    });
+
+    audioP.catch((err) => {
+      console.warn('Audio preload issue:', err);
+    });
 
     await Promise.race([
-      Promise.all([videoP, audioP, fontsP, rainP, dataP]),
-      cap
+      essentials,
+      delay(PRELOAD_MAX_WAIT_MS)
     ]);
   }
 
@@ -642,10 +677,7 @@ header.ripple span.figtree-adrift {
   function ensurePreloadAll(){
     if (!preloadAllPromise) {
       preloadAllDone = false;
-      preloadAllPromise = preloadAll().then((value) => {
-        preloadAllDone = true;
-        return value;
-      }).catch((err) => {
+      preloadAllPromise = preloadAll().catch((err) => {
         preloadAllDone = false;
         preloadAllPromise = null;
         throw err;
@@ -693,7 +725,7 @@ header.ripple span.figtree-adrift {
         console.error('Preload failed:', err);
       } finally {
         setLoadingUI(false);
-        revealMainContent();  // only after preload finishes (or the 7s cap)
+        revealMainContent();  // only after preload finishes (or the quick timeout fallback)
       }
     });
   }
@@ -1414,10 +1446,10 @@ function pickRandomDoubt() {
     });
   };
 
+  // Kick off resource preloading immediately; also retry once DOM is ready as a safety net
+  startPreload();
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', startPreload, { once: true });
-  } else {
-    startPreload();
   }
 </script>
 


### PR DESCRIPTION
## Summary
- start resource preloading as soon as the script loads and cap the intro loader to roughly 2.6 seconds
- seed placeholder boats and counts so the scene renders immediately while Supabase data completes
- keep non-essential audio loading asynchronous so it no longer blocks the intro transition

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cd56b3fec8832da1b662aa0984dfa0