### PR TITLE
Replace CTA hover effect with shader-based glow

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,19 +198,43 @@
     border:1px solid rgba(255,255,255,.28);
     background: rgba(255,255,255,.04);
     backdrop-filter: blur(3px);
-    transition: box-shadow .25s ease, transform .2s ease, border-color .25s ease, background .25s ease;
+    transition: transform .2s ease, border-color .25s ease, background .25s ease;
     cursor:pointer; user-select:none;
     display: inline-flex;
     align-items: center;
     justify-content: center;
     text-decoration: none;
     white-space: nowrap;
+    position: relative;
+    overflow: hidden;
   }
 
   .cta-btn--floating {
     position:fixed; left:50%; transform:translateX(-50%); bottom:16px; z-index:5;
   }
-  .cta-btn:hover{ box-shadow: 0 0 36px 12px rgba(255, 219, 90, 0.174), 0 0 8px 2px rgba(255,255,255,.25); border-color: rgba(255,255,255,.5); }
+  .cta-btn__shape {
+    position:absolute;
+    inset:0;
+    pointer-events:none;
+    opacity:0;
+    transition: opacity .35s ease;
+  }
+  .cta-btn__shape canvas {
+    width:100% !important;
+    height:100% !important;
+    display:block;
+  }
+  .cta-btn:hover .cta-btn__shape,
+  .cta-btn:focus-visible .cta-btn__shape,
+  .cta-btn:active .cta-btn__shape {
+    opacity:1;
+  }
+  .cta-btn:hover,
+  .cta-btn:focus-visible,
+  .cta-btn:active {
+    border-color: rgba(255,255,255,.45);
+    background: rgba(255,255,255,.07);
+  }
   .cta-btn:focus-visible{ outline:2px solid rgba(255, 200, 100, 0.35); outline-offset:3px; }
 
   /* Hidden media */
@@ -1444,6 +1468,299 @@ fetchTotalDoubts().then(count => {
     anims.forEach(a => a.reverse());
   });
 })();
+</script>
+
+<script type="module">
+import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js';
+
+const vertexShader = /* glsl */ `
+varying vec2 v_texcoord;
+void main() {
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+    v_texcoord = uv;
+}
+`;
+
+const fragmentShader = /* glsl */ `
+varying vec2 v_texcoord;
+
+uniform vec2 u_mouse;
+uniform vec2 u_resolution;
+uniform float u_pixelRatio;
+
+uniform float u_shapeSize;
+uniform float u_roundness;
+uniform float u_borderSize;
+uniform float u_circleSize;
+uniform float u_circleEdge;
+
+#ifndef PI
+#define PI 3.1415926535897932384626433832795
+#endif
+#ifndef TWO_PI
+#define TWO_PI 6.2831853071795864769252867665590
+#endif
+
+#ifndef VAR
+#define VAR 0
+#endif
+
+#ifndef FNC_COORD
+#define FNC_COORD
+vec2 coord(in vec2 p) {
+    p = p / u_resolution.xy;
+    if (u_resolution.x > u_resolution.y) {
+        p.x *= u_resolution.x / u_resolution.y;
+        p.x += (u_resolution.y - u_resolution.x) / u_resolution.y / 2.0;
+    } else {
+        p.y *= u_resolution.y / u_resolution.x;
+        p.y += (u_resolution.x - u_resolution.y) / u_resolution.x / 2.0;
+    }
+    p -= 0.5;
+    p *= vec2(-1.0, 1.0);
+    return p;
+}
+#endif
+
+#define st0 coord(gl_FragCoord.xy)
+#define mx coord(u_mouse * u_pixelRatio)
+
+float sdRoundRect(vec2 p, vec2 b, float r) {
+    vec2 d = abs(p - 0.5) * 4.2 - b + vec2(r);
+    return min(max(d.x, d.y), 0.0) + length(max(d, 0.0)) - r;
+}
+float sdCircle(in vec2 st, in vec2 center) {
+    return length(st - center) * 2.0;
+}
+float sdPoly(in vec2 p, in float w, in int sides) {
+    float a = atan(p.x, p.y) + PI;
+    float r = TWO_PI / float(sides);
+    float d = cos(floor(0.5 + a / r) * r - a) * length(max(abs(p) * 1.0, 0.0));
+    return d * 2.0 - w;
+}
+
+float aastep(float threshold, float value) {
+    float afwidth = length(vec2(dFdx(value), dFdy(value))) * 0.70710678118654757;
+    return smoothstep(threshold - afwidth, threshold + afwidth, value);
+}
+float fill(in float x) { return 1.0 - aastep(0.0, x); }
+float fill(float x, float size, float edge) {
+    return 1.0 - smoothstep(size - edge, size + edge, x);
+}
+float stroke(in float d, in float t) { return (1.0 - aastep(t, abs(d))); }
+float stroke(float x, float size, float w, float edge) {
+    float d = smoothstep(size - edge, size + edge, x + w * 0.5) - smoothstep(size - edge, size + edge, x - w * 0.5);
+    return clamp(d, 0.0, 1.0);
+}
+
+float strokeAA(float x, float size, float w, float edge) {
+    float afwidth = length(vec2(dFdx(x), dFdy(x))) * 0.70710678;
+    float d = smoothstep(size - edge - afwidth, size + edge + afwidth, x + w * 0.5)
+            - smoothstep(size - edge - afwidth, size + edge + afwidth, x - w * 0.5);
+    return clamp(d, 0.0, 1.0);
+}
+
+void main() {
+    vec2 st = st0 + 0.5;
+    vec2 posMouse = mx * vec2(1., -1.) + 0.5;
+
+    float size = u_shapeSize;
+    float roundness = u_roundness;
+    float borderSize = u_borderSize;
+    float circleSize = u_circleSize;
+    float circleEdge = u_circleEdge;
+
+    float sdfCircle = fill(
+        sdCircle(st, posMouse),
+        circleSize,
+        circleEdge
+    );
+
+    float sdf;
+    if (VAR == 0) {
+        sdf = sdRoundRect(st, vec2(size), roundness);
+        sdf = strokeAA(sdf, 0.0, borderSize, sdfCircle) * 4.0;
+    } else if (VAR == 1) {
+        sdf = sdCircle(st, vec2(0.5));
+        sdf = fill(sdf, 0.6, sdfCircle) * 1.2;
+    } else if (VAR == 2) {
+        sdf = sdCircle(st, vec2(0.5));
+        sdf = strokeAA(sdf, 0.58, 0.02, sdfCircle) * 4.0;
+    } else if (VAR == 3) {
+        sdf = sdPoly(st - vec2(0.5, 0.45), 0.3, 3);
+        sdf = fill(sdf, 0.05, sdfCircle) * 1.4;
+    }
+
+    vec3 color = vec3(1.0);
+    float alpha = sdf;
+    gl_FragColor = vec4(color.rgb, alpha);
+}
+`;
+
+class ShapeBlurEffect {
+  constructor(button, options = {}) {
+    this.button = button;
+    this.options = Object.assign({
+      variation: 0,
+      pixelRatioProp: 2,
+      shapeSize: 1.2,
+      roundness: 0.4,
+      borderSize: 0.05,
+      circleSize: 0.3,
+      circleEdge: 0.5
+    }, options);
+
+    this.mount = document.createElement('span');
+    this.mount.className = 'cta-btn__shape';
+    this.mount.setAttribute('aria-hidden', 'true');
+    button.insertBefore(this.mount, button.firstChild || null);
+
+    this.vMouse = new THREE.Vector2();
+    this.vMouseDamp = new THREE.Vector2();
+    this.vResolution = new THREE.Vector2();
+    this.lastTime = 0;
+
+    this.init();
+  }
+
+  init() {
+    if (!this.mount) return;
+
+    const { variation, pixelRatioProp, shapeSize, roundness, borderSize, circleSize, circleEdge } = this.options;
+
+    this.scene = new THREE.Scene();
+    this.camera = new THREE.OrthographicCamera();
+    this.camera.position.z = 1;
+
+    try {
+      this.renderer = new THREE.WebGLRenderer({ alpha: true, antialias: true });
+    } catch (err) {
+      console.warn('WebGL renderer unavailable for CTA effect:', err);
+      this.mount.remove();
+      return;
+    }
+    this.renderer.setClearColor(0x000000, 0);
+    this.mount.appendChild(this.renderer.domElement);
+    this.renderer.domElement.style.pointerEvents = 'none';
+
+    const geometry = new THREE.PlaneGeometry(1, 1);
+    this.material = new THREE.ShaderMaterial({
+      vertexShader,
+      fragmentShader,
+      uniforms: {
+        u_mouse: { value: this.vMouseDamp },
+        u_resolution: { value: this.vResolution },
+        u_pixelRatio: { value: pixelRatioProp },
+        u_shapeSize: { value: shapeSize },
+        u_roundness: { value: roundness },
+        u_borderSize: { value: borderSize },
+        u_circleSize: { value: circleSize },
+        u_circleEdge: { value: circleEdge }
+      },
+      defines: { VAR: variation },
+      transparent: true
+    });
+
+    this.quad = new THREE.Mesh(geometry, this.material);
+    this.scene.add(this.quad);
+
+    this.resize = this.resize.bind(this);
+    this.update = this.update.bind(this);
+    this.onPointerMove = this.onPointerMove.bind(this);
+    this.onPointerLeave = this.onPointerLeave.bind(this);
+
+    this.resize();
+    this.centerMouse();
+
+    window.addEventListener('resize', this.resize);
+    this.button.addEventListener('pointermove', this.onPointerMove);
+    this.button.addEventListener('pointerleave', this.onPointerLeave);
+
+    if (typeof ResizeObserver !== 'undefined') {
+      this.resizeObserver = new ResizeObserver(() => this.resize());
+      this.resizeObserver.observe(this.button);
+    }
+
+    if (typeof MutationObserver !== 'undefined') {
+      this.mutationObserver = new MutationObserver(() => {
+        if (!this.button.contains(this.mount)) {
+          this.button.insertBefore(this.mount, this.button.firstChild || null);
+          this.resize();
+          this.centerMouse();
+        }
+      });
+      this.mutationObserver.observe(this.button, { childList: true });
+    }
+
+    this.animationFrameId = requestAnimationFrame(this.update);
+  }
+
+  resize() {
+    if (!this.renderer) return;
+    const rect = this.button.getBoundingClientRect();
+    const w = rect.width || 1;
+    const h = rect.height || 1;
+
+    const dpr = Math.min(window.devicePixelRatio || 1, 2);
+
+    this.renderer.setPixelRatio(dpr);
+    this.renderer.setSize(w, h, false);
+
+    this.camera.left = -w / 2;
+    this.camera.right = w / 2;
+    this.camera.top = h / 2;
+    this.camera.bottom = -h / 2;
+    this.camera.updateProjectionMatrix();
+
+    if (this.quad) {
+      this.quad.scale.set(w, h, 1);
+    }
+
+    this.vResolution.set(w, h).multiplyScalar(dpr);
+    if (this.material) {
+      this.material.uniforms.u_pixelRatio.value = dpr;
+    }
+  }
+
+  centerMouse() {
+    const rect = this.button.getBoundingClientRect();
+    const cx = rect.width / 2;
+    const cy = rect.height / 2;
+    this.vMouse.set(cx, cy);
+    this.vMouseDamp.copy(this.vMouse);
+  }
+
+  onPointerMove(event) {
+    const rect = this.button.getBoundingClientRect();
+    this.vMouse.set(event.clientX - rect.left, event.clientY - rect.top);
+  }
+
+  onPointerLeave() {
+    this.centerMouse();
+  }
+
+  update(time) {
+    if (!this.renderer) return;
+    const now = time ? time * 0.001 : performance.now() * 0.001;
+    const delta = this.lastTime ? Math.max(now - this.lastTime, 1 / 120) : 1 / 60;
+    this.lastTime = now;
+
+    this.vMouseDamp.x = THREE.MathUtils.damp(this.vMouseDamp.x, this.vMouse.x, 8, delta);
+    this.vMouseDamp.y = THREE.MathUtils.damp(this.vMouseDamp.y, this.vMouse.y, 8, delta);
+
+    this.renderer.render(this.scene, this.camera);
+    this.animationFrameId = requestAnimationFrame(this.update);
+  }
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  const buttons = document.querySelectorAll('.cta-btn');
+  buttons.forEach(button => {
+    if (!button || button.dataset.shapeBlurAttached === '1') return;
+    button.dataset.shapeBlurAttached = '1';
+    new ShapeBlurEffect(button);
+  });
+});
 </script>
 
 </body></html>


### PR DESCRIPTION
## Summary
- add a WebGL shader-driven hover overlay for CTA buttons using Three.js to recreate the ShapeBlur effect
- update CTA button styles to host the canvas overlay and adjust hover/focus appearance

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cd5fc6a964832d99430bd383225810