### PR TITLE
Align CTA shader with pill border

### DIFF
--- a/index.html
+++ b/index.html
@@ -218,6 +218,8 @@
     pointer-events:none;
     opacity:0;
     transition: opacity .35s ease;
+    border-radius: inherit;
+    overflow: hidden;
   }
   .cta-btn__shape canvas {
     width:100% !important;
@@ -1488,7 +1490,6 @@ uniform vec2 u_mouse;
 uniform vec2 u_resolution;
 uniform float u_pixelRatio;
 
-uniform float u_shapeSize;
 uniform float u_roundness;
 uniform float u_borderSize;
 uniform float u_circleSize;
@@ -1501,56 +1502,8 @@ uniform float u_circleEdge;
 #define TWO_PI 6.2831853071795864769252867665590
 #endif
 
-#ifndef VAR
-#define VAR 0
-#endif
-
-#ifndef FNC_COORD
-#define FNC_COORD
-vec2 coord(in vec2 p) {
-    p = p / u_resolution.xy;
-    if (u_resolution.x > u_resolution.y) {
-        p.x *= u_resolution.x / u_resolution.y;
-        p.x += (u_resolution.y - u_resolution.x) / u_resolution.y / 2.0;
-    } else {
-        p.y *= u_resolution.y / u_resolution.x;
-        p.y += (u_resolution.x - u_resolution.y) / u_resolution.x / 2.0;
-    }
-    p -= 0.5;
-    p *= vec2(-1.0, 1.0);
-    return p;
-}
-#endif
-
-#define st0 coord(gl_FragCoord.xy)
-#define mx coord(u_mouse * u_pixelRatio)
-
-float sdRoundRect(vec2 p, vec2 b, float r) {
-    vec2 d = abs(p - 0.5) * 4.2 - b + vec2(r);
-    return min(max(d.x, d.y), 0.0) + length(max(d, 0.0)) - r;
-}
-float sdCircle(in vec2 st, in vec2 center) {
-    return length(st - center) * 2.0;
-}
-float sdPoly(in vec2 p, in float w, in int sides) {
-    float a = atan(p.x, p.y) + PI;
-    float r = TWO_PI / float(sides);
-    float d = cos(floor(0.5 + a / r) * r - a) * length(max(abs(p) * 1.0, 0.0));
-    return d * 2.0 - w;
-}
-
-float aastep(float threshold, float value) {
-    float afwidth = length(vec2(dFdx(value), dFdy(value))) * 0.70710678118654757;
-    return smoothstep(threshold - afwidth, threshold + afwidth, value);
-}
-float fill(in float x) { return 1.0 - aastep(0.0, x); }
 float fill(float x, float size, float edge) {
     return 1.0 - smoothstep(size - edge, size + edge, x);
-}
-float stroke(in float d, in float t) { return (1.0 - aastep(t, abs(d))); }
-float stroke(float x, float size, float w, float edge) {
-    float d = smoothstep(size - edge, size + edge, x + w * 0.5) - smoothstep(size - edge, size + edge, x - w * 0.5);
-    return clamp(d, 0.0, 1.0);
 }
 
 float strokeAA(float x, float size, float w, float edge) {
@@ -1561,39 +1514,27 @@ float strokeAA(float x, float size, float w, float edge) {
 }
 
 void main() {
-    vec2 st = st0 + 0.5;
-    vec2 posMouse = mx * vec2(1., -1.) + 0.5;
+    vec2 buttonSize = u_resolution / max(u_pixelRatio, 0.0001);
+    float minDim = min(buttonSize.x, buttonSize.y);
+    float cornerRadius = clamp(u_roundness, 0.0, minDim * 0.5);
+    float borderWidth = max(u_borderSize, 0.0);
 
-    float size = u_shapeSize;
-    float roundness = u_roundness;
-    float borderSize = u_borderSize;
-    float circleSize = u_circleSize;
-    float circleEdge = u_circleEdge;
+    vec2 fragPx = v_texcoord * buttonSize;
+    vec2 halfSize = buttonSize * 0.5;
+    vec2 q = abs(fragPx - halfSize) - (halfSize - vec2(cornerRadius));
+    float sdf = length(max(q, 0.0)) + min(max(q.x, q.y), 0.0) - cornerRadius;
 
-    float sdfCircle = fill(
-        sdCircle(st, posMouse),
-        circleSize,
-        circleEdge
-    );
+    vec2 mousePx = clamp(u_mouse, vec2(0.0), buttonSize);
+    vec2 diff = (fragPx - mousePx) / max(minDim, 0.0001);
+    float sdfCircle = fill(length(diff) * 2.0, u_circleSize, u_circleEdge);
 
-    float sdf;
-    if (VAR == 0) {
-        sdf = sdRoundRect(st, vec2(size), roundness);
-        sdf = strokeAA(sdf, 0.0, borderSize, sdfCircle) * 4.0;
-    } else if (VAR == 1) {
-        sdf = sdCircle(st, vec2(0.5));
-        sdf = fill(sdf, 0.6, sdfCircle) * 1.2;
-    } else if (VAR == 2) {
-        sdf = sdCircle(st, vec2(0.5));
-        sdf = strokeAA(sdf, 0.58, 0.02, sdfCircle) * 4.0;
-    } else if (VAR == 3) {
-        sdf = sdPoly(st - vec2(0.5, 0.45), 0.3, 3);
-        sdf = fill(sdf, 0.05, sdfCircle) * 1.4;
+    float alpha = 0.0;
+    if (borderWidth > 0.0) {
+        float width = max(borderWidth, 0.001);
+        alpha = strokeAA(sdf, -width * 0.5, width, sdfCircle);
     }
 
-    vec3 color = vec3(1.0);
-    float alpha = sdf;
-    gl_FragColor = vec4(color.rgb, alpha);
+    gl_FragColor = vec4(vec3(1.0), alpha);
 }
 `;
 
@@ -1603,9 +1544,8 @@ class ShapeBlurEffect {
     this.options = Object.assign({
       variation: 0,
       pixelRatioProp: 2,
-      shapeSize: 1.2,
-      roundness: 0.4,
-      borderSize: 0.05,
+      roundness: 0,
+      borderSize: 1,
       circleSize: 0.3,
       circleEdge: 0.5
     }, options);
@@ -1626,7 +1566,7 @@ class ShapeBlurEffect {
   init() {
     if (!this.mount) return;
 
-    const { variation, pixelRatioProp, shapeSize, roundness, borderSize, circleSize, circleEdge } = this.options;
+    const { variation, pixelRatioProp, roundness, borderSize, circleSize, circleEdge } = this.options;
 
     this.scene = new THREE.Scene();
     this.camera = new THREE.OrthographicCamera();
@@ -1651,7 +1591,6 @@ class ShapeBlurEffect {
         u_mouse: { value: this.vMouseDamp },
         u_resolution: { value: this.vResolution },
         u_pixelRatio: { value: pixelRatioProp },
-        u_shapeSize: { value: shapeSize },
         u_roundness: { value: roundness },
         u_borderSize: { value: borderSize },
         u_circleSize: { value: circleSize },
@@ -1719,6 +1658,25 @@ class ShapeBlurEffect {
     this.vResolution.set(w, h).multiplyScalar(dpr);
     if (this.material) {
       this.material.uniforms.u_pixelRatio.value = dpr;
+      const styles = window.getComputedStyle ? getComputedStyle(this.button) : null;
+      const parsePx = value => {
+        const parsed = parseFloat(value);
+        return Number.isNaN(parsed) ? 0 : parsed;
+      };
+
+      let borderWidth = this.options.borderSize || 0;
+      let radius = this.options.roundness || 0;
+
+      if (styles) {
+        const parsedBorder = parsePx(styles.borderTopWidth || styles.borderWidth);
+        const parsedRadius = parsePx(styles.borderTopLeftRadius || styles.borderRadius);
+        if (parsedBorder > 0) borderWidth = parsedBorder;
+        if (parsedRadius > 0) radius = parsedRadius;
+      }
+
+      const maxRadius = Math.min(radius, Math.min(w, h) * 0.5);
+      this.material.uniforms.u_borderSize.value = borderWidth;
+      this.material.uniforms.u_roundness.value = maxRadius;
     }
   }
 


### PR DESCRIPTION
## Summary
- reshape the CTA shader so it renders along the pill border using the button's true dimensions
- sync shader uniforms with computed border radius/width and clip the canvas wrapper to the rounded outline

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd9eb43f08832da20140f715859ef2