### PR TITLE
Reduce preload safety timeout to 4 seconds

### DIFF
--- a/index.html
+++ b/index.html
@@ -617,8 +617,8 @@ header.ripple span.figtree-adrift {
     const rainP  = preloadScriptAlreadyInPage('rain.js');
     const dataP  = preloadData();
 
-    // Safety cap so we don’t hang forever waiting on a stubborn canplaythrough
-    const cap = new Promise(res => setTimeout(res, 7000));
+    // Safety cap (4s) so we don’t hang forever waiting on a stubborn canplaythrough
+    const cap = new Promise(res => setTimeout(res, 4000));
 
     await Promise.race([
       Promise.all([videoP, audioP, fontsP, rainP, dataP]),


### PR DESCRIPTION
## Summary
- update the preload safety cap comment to note the new duration
- shorten the timeout to resolve after four seconds so the loader clears sooner

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cea880fbf4832da8895a9f56e46599