### PR TITLE
Add cheers view with support column

### DIFF
--- a/index.html
+++ b/index.html
@@ -230,6 +230,139 @@
     pointer-events: none;
   }
 
+  .is-hidden {
+    display: none !important;
+  }
+
+  /* Support column */
+  .support-column {
+    position: fixed;
+    top: 136px;
+    right: 24px;
+    width: min(320px, calc(100vw - 48px));
+    max-height: calc(100vh - 188px);
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    padding: 18px;
+    border-radius: 22px;
+    background: rgba(14, 18, 28, 0.72);
+    border: 1px solid rgba(255,255,255,0.08);
+    box-shadow: 0 18px 38px rgba(0,0,0,0.45);
+    backdrop-filter: blur(14px);
+    color: rgba(236,236,237,0.86);
+    z-index: 5;
+    box-sizing: border-box;
+  }
+
+  .support-column[hidden] {
+    display: none !important;
+  }
+
+  .support-column__header {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .support-column__title {
+    margin: 0;
+    font-family: "Figtree", ui-sans-serif, system-ui, sans-serif;
+    font-size: 12px;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: rgba(236,236,237,0.62);
+  }
+
+  .support-column__subtitle {
+    margin: 0;
+    font-size: 13px;
+    line-height: 1.6;
+    color: rgba(236,236,237,0.72);
+    letter-spacing: 0.01em;
+  }
+
+  .support-column__list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    overflow-y: auto;
+    padding-right: 2px;
+    scrollbar-width: thin;
+  }
+
+  .support-column__list::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  .support-column__list::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .support-column__list::-webkit-scrollbar-thumb {
+    background: rgba(255,255,255,0.16);
+    border-radius: 999px;
+  }
+
+  .support-column__item {
+    margin: 0;
+  }
+
+  .support-item {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 10px;
+    padding: 15px 16px 14px;
+    border-radius: 18px;
+    border: 1px solid rgba(255,255,255,0.08);
+    background: rgba(255,255,255,0.05);
+    color: rgba(236,236,237,0.9);
+    font-family: "Figtree", ui-sans-serif, system-ui, sans-serif;
+    font-size: 15px;
+    line-height: 1.6;
+    text-align: left;
+    cursor: pointer;
+    transition: border-color .22s ease, background .22s ease, transform .22s ease;
+  }
+
+  .support-item:hover,
+  .support-item:focus-visible {
+    border-color: rgba(255,255,255,0.2);
+    background: rgba(255,255,255,0.1);
+    transform: translateY(-1px);
+  }
+
+  .support-item:focus-visible {
+    outline: 2px solid rgba(255, 200, 120, 0.45);
+    outline-offset: 2px;
+  }
+
+  .support-item__text {
+    display: block;
+    width: 100%;
+    color: inherit;
+    word-break: break-word;
+  }
+
+  .support-item__meta {
+    display: block;
+    font-size: 11px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(236,236,237,0.55);
+  }
+
+  .support-column__empty {
+    font-size: 13px;
+    color: rgba(236,236,237,0.65);
+    line-height: 1.6;
+  }
+
   @media (max-width: 600px) {
     .view-toggle {
       top: 72px;
@@ -240,6 +373,32 @@
       padding: 6px 14px;
       font-size: 11px;
       letter-spacing: 0.05em;
+    }
+  }
+
+  @media (max-width: 640px) {
+    .support-column {
+      top: 118px;
+      right: 16px;
+      left: 16px;
+      width: auto;
+      max-height: calc(100vh - 210px);
+      padding: 16px;
+      gap: 12px;
+    }
+
+    .support-column__title {
+      font-size: 11px;
+      letter-spacing: 0.14em;
+    }
+
+    .support-column__subtitle {
+      font-size: 12px;
+    }
+
+    .support-item {
+      font-size: 14px;
+      padding: 14px;
     }
   }
 
@@ -588,6 +747,14 @@ header.ripple span.figtree-adrift {
       <button type="button" class="view-toggle__option" data-view="affirmations" aria-pressed="false">Cheers</button>
     </div>
 
+    <aside class="support-column" aria-label="Community cheers" hidden>
+      <div class="support-column__header">
+        <h2 class="support-column__title">Cheers from the drift</h2>
+        <p class="support-column__subtitle">Tap a cheer to unfold a note of support.</p>
+      </div>
+      <ul class="support-column__list" id="supportList"></ul>
+    </aside>
+
     <!-- media -->
     <video id="boatVideo" src="boat.mp4" loop="" muted="" playsinline="" preload="auto"></video>
     <audio id="bgAudio" src="sound.mp3" loop="" preload="auto"></audio>
@@ -614,15 +781,194 @@ header.ripple span.figtree-adrift {
   const doubtCounter = document.getElementById('doubt-counter');
   const viewToggle = document.querySelector('.view-toggle');
   const viewToggleButtons = viewToggle ? viewToggle.querySelectorAll('.view-toggle__option') : [];
+  const supportColumn = document.querySelector('.support-column');
+  const supportList = document.getElementById('supportList');
+  const hintEl = document.querySelector('.hint');
+
+  const SUPPORT_CHEERS = [
+    {
+      id: 'cheer-01',
+      text: 'Someone is proud of the way you keep going, even when the tide feels against you.',
+      attribution: 'Shared by a fellow traveler',
+      date: '2025-09-10',
+      active: true
+    },
+    {
+      id: 'cheer-02',
+      text: 'Your questions are welcome here. Take a breath—none of this has to be solved tonight.',
+      attribution: 'A quiet voice at the shoreline',
+      date: '2025-08-29',
+      active: true
+    },
+    {
+      id: 'cheer-03',
+      text: 'Even when you feel stuck, your presence is already a gift. Someone notices the care you carry.',
+      attribution: 'Left in lantern light',
+      date: '2025-07-18',
+      active: true
+    },
+    {
+      id: 'cheer-04',
+      text: 'Rest when you can. The sea will keep moving, and you can rejoin it when your breath is steadier.',
+      attribution: 'From a midnight drift',
+      date: '2025-06-04',
+      active: true
+    },
+    {
+      id: 'cheer-05',
+      text: 'You have not failed by feeling uncertain. You are simply human, and that is more than enough.',
+      attribution: 'A companion across the water',
+      date: '2025-04-22',
+      active: true
+    },
+    {
+      id: 'cheer-06',
+      text: 'There is room for joy alongside the questions. Let a little light in, even if it’s only for a moment.',
+      attribution: 'Message folded into a sail',
+      date: '2025-03-15',
+      active: true
+    },
+    {
+      id: 'cheer-07',
+      text: 'You don’t have to carry every answer alone. Let the water hold some of the weight tonight.',
+      attribution: 'Anonymous driftmate',
+      date: '2025-02-02',
+      active: true
+    },
+    {
+      id: 'cheer-08',
+      text: 'Someone is celebrating the way you continue to care, even with a tired heart. That tenderness matters.',
+      attribution: 'Shared with gratitude',
+      date: '2024-12-19',
+      active: true
+    }
+  ];
+
+  let currentView = 'doubts';
+
+  function escapeHtml(str = '') {
+    return String(str).replace(/[&<>"']/g, (char) => {
+      switch (char) {
+        case '&': return '&amp;';
+        case '<': return '&lt;';
+        case '>': return '&gt;';
+        case '"': return '&quot;';
+        case "'": return '&#39;';
+        default: return char;
+      }
+    });
+  }
+
+  function normalizeTextPreview(text, maxLength = 120) {
+    const clean = String(text || '').replace(/\s+/g, ' ').trim();
+    if (clean.length <= maxLength) return clean;
+    return clean.slice(0, Math.max(0, maxLength - 1)).trimEnd() + '…';
+  }
+
+  function renderSupportColumn() {
+    if (!supportList) return;
+    supportList.textContent = '';
+
+    const activeItems = SUPPORT_CHEERS.filter(item => item && item.active !== false);
+
+    if (!activeItems.length) {
+      const emptyItem = document.createElement('li');
+      emptyItem.className = 'support-column__empty';
+      emptyItem.textContent = 'Cheers are on their way.';
+      supportList.appendChild(emptyItem);
+      return;
+    }
+
+    activeItems.forEach((item) => {
+      const li = document.createElement('li');
+      li.className = 'support-column__item';
+
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'support-item';
+      button.dataset.cheerId = item.id;
+      button.addEventListener('click', () => openCheerNote(item));
+
+      const textSpan = document.createElement('span');
+      textSpan.className = 'support-item__text';
+      textSpan.textContent = item.text;
+      button.appendChild(textSpan);
+
+      const metaParts = [];
+      if (item.date) {
+        const parsed = new Date(item.date + 'T00:00:00');
+        if (!Number.isNaN(parsed.getTime())) {
+          metaParts.push(parsed.toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' }));
+        }
+      }
+      if (item.attribution) {
+        metaParts.push(item.attribution);
+      }
+      if (metaParts.length) {
+        const meta = document.createElement('span');
+        meta.className = 'support-item__meta';
+        meta.textContent = metaParts.join(' • ');
+        button.appendChild(meta);
+      }
+
+      button.setAttribute('aria-label', `Open cheer: ${normalizeTextPreview(item.text, 140)}`);
+      li.appendChild(button);
+      supportList.appendChild(li);
+    });
+  }
+
+  function openCheerNote(item) {
+    const metaParts = [];
+    if (item.date) {
+      const parsed = new Date(item.date + 'T00:00:00');
+      if (!Number.isNaN(parsed.getTime())) {
+        metaParts.push(parsed.toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' }));
+      }
+    }
+    if (item.attribution) {
+      metaParts.push(item.attribution);
+    }
+
+    const metaHTML = metaParts.length ? `<div class="note-meta">${escapeHtml(metaParts.join(' • '))}</div>` : '';
+    const bodyHTML = `<div class="note-text">${escapeHtml(item.text).replace(/\n/g, '<br>')}</div>`;
+
+    createNote({
+      x: innerWidth / 2,
+      y: innerHeight / 2,
+      title: 'Community Cheer',
+      bodyHTML,
+      metaHTML,
+      boat: null,
+      startScale: 0.72
+    });
+  }
+
+  function updateToggleState() {
+    if (!viewToggleButtons.length) return;
+    viewToggleButtons.forEach((btn) => {
+      const isActive = (btn.dataset.view === currentView);
+      btn.classList.toggle('is-active', isActive);
+      btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    });
+  }
+
+  function setView(view) {
+    const normalized = view === 'affirmations' ? 'affirmations' : 'doubts';
+    if (normalized === currentView) return;
+    currentView = normalized;
+    updateToggleState();
+    if (currentView === 'affirmations') {
+      renderSupportColumn();
+    }
+    applyViewState();
+  }
 
   if (viewToggleButtons.length) {
     viewToggleButtons.forEach((button) => {
       button.addEventListener('click', () => {
-        viewToggleButtons.forEach((btn) => {
-          const isActive = btn === button;
-          btn.classList.toggle('is-active', isActive);
-          btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
-        });
+        const targetView = button.dataset.view || 'doubts';
+        if (targetView === currentView) return;
+        setView(targetView);
       });
     });
   }
@@ -863,6 +1209,33 @@ function animateDoubtCounter(el, targetValue) {
   }
   addEventListener('resize', resize);
   resize();
+
+  function applyViewState() {
+    const showingCheers = currentView === 'affirmations';
+
+    if (supportColumn) {
+      supportColumn.hidden = !showingCheers;
+    }
+
+    if (canvas) {
+      canvas.classList.toggle('is-hidden', showingCheers);
+      canvas.setAttribute('aria-hidden', showingCheers ? 'true' : 'false');
+    }
+
+    if (hintEl) {
+      hintEl.classList.toggle('is-hidden', showingCheers);
+    }
+
+    if (releaseBtn) {
+      const label = showingCheers ? 'Release a cheer' : 'Release your doubt';
+      releaseBtn.textContent = label;
+      releaseBtn.setAttribute('aria-label', label);
+    }
+  }
+
+  renderSupportColumn();
+  updateToggleState();
+  applyViewState();
 
   /* ====== Media autoplay ====== */
 const DEFAULT_VOL = 0.28;
@@ -1333,8 +1706,12 @@ function pickRandomDoubt() {
   function openComposerNote() {
     composerOpen = true;
 
+    const isCheersView = currentView === 'affirmations';
+    const noteTitle = isCheersView ? 'Release a cheer' : 'Release your doubt';
+    const placeholderText = isCheersView ? 'Type your cheer (200 characters max)' : 'Type your doubt (200 characters max)';
+
     const body = `
-      <textarea class="compose-field" id="doubtInput" maxlength="200" placeholder="Type your doubt (200 characters max)"></textarea>
+      <textarea class="compose-field" id="releaseInput" maxlength="200" placeholder="${placeholderText}"></textarea>
       <div class="compose-foot">
         <div><span id="charCount">0</span>/200</div>
         <button class="pill-btn" id="submitDoubt" type="button">Release</button>
@@ -1345,14 +1722,14 @@ function pickRandomDoubt() {
     createNote({
       x: innerWidth / 2,
       y: innerHeight / 2,
-      title: 'Release your doubt',
+      title: noteTitle,
       bodyHTML: body,
       metaHTML: '',
       boat: null,
       startScale: 0.72
     });
 
-    const input = document.getElementById('doubtInput');
+    const input = document.getElementById('releaseInput');
     const count = document.getElementById('charCount');
     const submit = document.getElementById('submitDoubt');
 


### PR DESCRIPTION
## Summary
- add a fixed support column that lists curated cheers and stays hidden until the Cheers view is active
- wire the Doubts/Cheers toggle so Cheers shows the support column, hides drifting doubts, and updates the CTA copy
- adjust the composer note to say "Release a cheer" with a matching placeholder when the Cheers view is active

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf3d10f50c832da09c0d3bbeb4097c