### PR TITLE
Add Open Graph metadata image for social sharing

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,13 +18,16 @@
 <meta property="og:description" content="A quiet place to anonymously share doubts as paper boats, or read others’ drifting doubts.">
 <meta property="og:url" content="https://adrift.site/">
 <meta property="og:type" content="website">
-<meta property="og:image" content="https://adrift.site/adrift-preview.jpg"> <!-- Replace with your actual image -->
+<meta property="og:image" content="Opengraph-adrift.jpg">
+<meta property="og:image:type" content="image/jpeg">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
 
 <!-- Twitter Card -->
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Adrift — A Quiet Place to Share or Read Anonymous Doubts">
 <meta name="twitter:description" content="Adrift is a quiet space where doubts drift as paper boats — shared anonymously, read quietly.">
-<meta name="twitter:image" content="https://adrift.site/adrift-preview.jpg"> <!-- Replace -->
+<meta name="twitter:image" content="Opengraph-adrift.jpg">
 
 <!-- Schema.org (Structured Data for AEO) -->
 <script type="application/ld+json">


### PR DESCRIPTION
## Summary
- reference the new Open Graph preview image and add metadata for its dimensions
- update the Twitter card preview to use the new image

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1d8f07db0832dac116e9f81cb4301