### PR TITLE
Use absolute social sharing image URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,8 @@
 <meta property="og:description" content="A quiet place to anonymously share doubts as paper boats, or read others’ drifting doubts.">
 <meta property="og:url" content="https://adrift.site/">
 <meta property="og:type" content="website">
-<meta property="og:image" content="Opengraph-adrift.jpg">
+<meta property="og:image" content="https://adrift.site/Opengraph-adrift.jpg">
+<meta property="og:image:secure_url" content="https://adrift.site/Opengraph-adrift.jpg">
 <meta property="og:image:type" content="image/jpeg">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
@@ -37,7 +38,7 @@
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Adrift — A Quiet Place to Share or Read Anonymous Doubts">
 <meta name="twitter:description" content="Adrift is a quiet space where doubts drift as paper boats — shared anonymously, read quietly.">
-<meta name="twitter:image" content="Opengraph-adrift.jpg">
+<meta name="twitter:image" content="https://adrift.site/Opengraph-adrift.jpg">
 
 <!-- Schema.org (Structured Data for AEO) -->
 <script type="application/ld+json">


### PR DESCRIPTION
## Summary
- update the Open Graph and Twitter card image tags to use the hosted HTTPS image
- add og:image:secure_url for improved crawler compatibility

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d69b9bd3a8832d9eb6a09a8af56361