### PR TITLE
Reset support notes fetch cache on retries

### DIFF
--- a/index.html
+++ b/index.html
@@ -1326,6 +1326,9 @@ header.ripple span.figtree-adrift {
     updateToggleState();
     reseedBoatsForCurrentView();
     applyViewState();
+    if (currentView === 'affirmations' && ACTIVE_SUPPORT_NOTES.length === 0) {
+      ensureSupportData(400);
+    }
   }
 
   if (viewToggleButtons.length) {
@@ -1658,10 +1661,14 @@ async function ensureSupportData(limit = 400) {
     try {
       const notes = await fetchSupportNotes(limit);
       setSupportNotes(notes);
+      if (!notes.length) {
+        supportFetchPromise = null;
+      }
       return notes;
     } catch (err) {
       console.error('Failed to load support notes:', err);
       setSupportNotes([]);
+      supportFetchPromise = null;
       return [];
     }
   })();
@@ -2182,6 +2189,9 @@ addEventListener('pageshow', (event) => {
     scheduleVideoReadyCheck();
   }
   resetVideoWatchdog();
+  if (currentView === 'affirmations' || ACTIVE_SUPPORT_NOTES.length === 0) {
+    ensureSupportData(400);
+  }
 });
 
   /* ===== Boats ===== */


### PR DESCRIPTION
### Motivation
- Allow the support notes flow to recover from failed or empty fetches so later attempts can retry and repopulate the Care list.
- Trigger lightweight refreshes on view switches and navigation so the UI can request support data again after an aborted/failed fetch.

### Description
- Clear the cached fetch promise by setting `supportFetchPromise = null` when `fetchSupportNotes` throws or returns an empty array inside `ensureSupportData` in `index.html`.
- Call `ensureSupportData(400)` when switching to the Care view via `setView('affirmations')` if `ACTIVE_SUPPORT_NOTES.length === 0` so the list repopulates immediately after a previous failure.
- Call `ensureSupportData(400)` in the `pageshow` handler when `currentView === 'affirmations'` or `ACTIVE_SUPPORT_NOTES.length === 0` to trigger a retry on return/navigation.
- Changes applied to `index.html` and committed with message "Reset support fetch cache on retry".

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698751f38754832d83789b3727dba820)