### PR TITLE
Retry support notes fetch when active list remains empty

### DIFF
--- a/index.html
+++ b/index.html
@@ -1179,6 +1179,7 @@ header.ripple span.figtree-adrift {
 
   function pickRandomCareNote() {
     if (!ACTIVE_SUPPORT_NOTES.length) {
+      ensureSupportData(400);
       return {
         id: 'care-placeholder',
         text: 'Care notes are on their way.',
@@ -1326,6 +1327,9 @@ header.ripple span.figtree-adrift {
     updateToggleState();
     reseedBoatsForCurrentView();
     applyViewState();
+    if (currentView === 'affirmations' && ACTIVE_SUPPORT_NOTES.length === 0) {
+      ensureSupportData(400);
+    }
   }
 
   if (viewToggleButtons.length) {
@@ -1658,10 +1662,14 @@ async function ensureSupportData(limit = 400) {
     try {
       const notes = await fetchSupportNotes(limit);
       setSupportNotes(notes);
+      if (!notes.length || ACTIVE_SUPPORT_NOTES.length === 0) {
+        supportFetchPromise = null;
+      }
       return notes;
     } catch (err) {
       console.error('Failed to load support notes:', err);
       setSupportNotes([]);
+      supportFetchPromise = null;
       return [];
     }
   })();
@@ -2182,6 +2190,9 @@ addEventListener('pageshow', (event) => {
     scheduleVideoReadyCheck();
   }
   resetVideoWatchdog();
+  if (currentView === 'affirmations' || ACTIVE_SUPPORT_NOTES.length === 0) {
+    ensureSupportData(400);
+  }
 });
 
   /* ===== Boats ===== */


### PR DESCRIPTION
### Motivation
- Ensure the support/"Care" flow can recover when a fetch yields no notes or normalization filters them all out so later UI interactions can retry and populate the list.
- Trigger a lightweight retry when the UI requests a care note while the active list is empty so the placeholder path can kick off a background fetch.

### Description
- Clear the cached `supportFetchPromise` inside `ensureSupportData` when the fetched `notes` array is empty or `ACTIVE_SUPPORT_NOTES.length === 0` so subsequent calls will re-fetch.
- Call `ensureSupportData(400)` from `pickRandomCareNote` when `ACTIVE_SUPPORT_NOTES` is empty so requesting a placeholder will begin a retry in the background.
- Preserve existing error handling that clears the cached promise on fetch exceptions and normalizes support notes via `setSupportNotes` and `initializeSupportPool`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698751f38754832d83789b3727dba820)