### PR TITLE
Ensure care notes refresh when returning to Care tab (prevent stuck empty state)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1080,6 +1080,16 @@ header.ripple span.figtree-adrift {
   let SHUFFLED_SUPPORT_NOTES = [];
   let USED_SUPPORT_IDS = new Set();
   let supportFetchPromise = null;
+  let lastSupportFetchAt = 0;
+  const SUPPORT_REFRESH_MS = 2 * 60 * 1000;
+
+  function supportNeedsRefresh() {
+    if (!supportList) return !ACTIVE_SUPPORT_NOTES.length;
+    const isStale = !lastSupportFetchAt || (Date.now() - lastSupportFetchAt) > SUPPORT_REFRESH_MS;
+    return !ACTIVE_SUPPORT_NOTES.length
+      || Boolean(supportList.querySelector('.support-column__empty'))
+      || isStale;
+  }
 
   function normalizeSupportItem(raw = {}, fallbackRow = {}, index = 0) {
     if (!raw) return null;
@@ -1326,8 +1336,8 @@ header.ripple span.figtree-adrift {
     updateToggleState();
     reseedBoatsForCurrentView();
     applyViewState();
-    if (currentView === 'affirmations' && ACTIVE_SUPPORT_NOTES.length === 0) {
-      ensureSupportData(400);
+    if (currentView === 'affirmations') {
+      ensureSupportData(400, { force: supportNeedsRefresh() });
     }
   }
 
@@ -1655,21 +1665,25 @@ async function fetchSupportNotes(limit = 400) {
     .slice(0, limit);
 }
 
-async function ensureSupportData(limit = 400) {
+async function ensureSupportData(limit = 400, { force = false } = {}) {
+  if (!force && ACTIVE_SUPPORT_NOTES.length) {
+    renderSupportColumn();
+    return ACTIVE_SUPPORT_NOTES;
+  }
   if (supportFetchPromise) return supportFetchPromise;
   supportFetchPromise = (async () => {
     try {
       const notes = await fetchSupportNotes(limit);
       setSupportNotes(notes);
-      if (!notes.length) {
-        supportFetchPromise = null;
-      }
+      lastSupportFetchAt = Date.now();
       return notes;
     } catch (err) {
       console.error('Failed to load support notes:', err);
       setSupportNotes([]);
-      supportFetchPromise = null;
+      lastSupportFetchAt = Date.now();
       return [];
+    } finally {
+      supportFetchPromise = null;
     }
   })();
   return supportFetchPromise;
@@ -2190,7 +2204,7 @@ addEventListener('pageshow', (event) => {
   }
   resetVideoWatchdog();
   if (currentView === 'affirmations' || ACTIVE_SUPPORT_NOTES.length === 0) {
-    ensureSupportData(400);
+    ensureSupportData(400, { force: supportNeedsRefresh() });
   }
 });
 


### PR DESCRIPTION
### Motivation
- Users reported the Care column sometimes stayed in the empty state (`"Care notes are on their way."`) after navigating away and returning to the Care tab. 
- The previous workaround did not reliably re-fetch or re-render data after page visibility changes or history restores. 
- The goal is a durable fix that re-fetches when the support data is empty or stale so the UI no longer gets stuck on the placeholder.

### Description
- Added `lastSupportFetchAt` and `SUPPORT_REFRESH_MS` and a `supportNeedsRefresh()` helper that treats an empty list, the placeholder DOM node, or a stale fetch timestamp as reasons to refresh. 
- Updated `ensureSupportData` to accept a `force` option, to early-render when data is present, to update `lastSupportFetchAt`, and to always clear `supportFetchPromise` in `finally` so subsequent refreshes are allowed. 
- Call sites that show or restore the Care view now invoke `ensureSupportData(..., { force: supportNeedsRefresh() })` (for example when switching to the Care view and on `pageshow`) to trigger re-fetch when appropriate. 
- Kept existing behavior of seeding the preload flow but made refresh decisions defensive so the support column will re-render or re-fetch only when needed.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69875b5f7c50832dba0d556bc9fce706)